### PR TITLE
Make groupID, topics and `user_names` inserting configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,23 @@
 In different terminal windows:
 
 1. Start `kafka` and `dgraph` with `docker-compose up`
-1. Run the scraper with `go run scraper/main/main.go`
-1. Run the dgraph inserter with `go run dgraph-inserter/main/main.go`
-1. Run the neo4j inserter with `go run neo4j-inserter/main/main.go`
-1. Run the postgres inserter with `go run postgres-inserter/main/main.go`
+
+> For the scraper, make sure to set the following environment variables:
+> - `KAFKA_GROUPID`
+> - `KAFKA_NAME_TOPIC` - read from topic
+> - `KAFKA_INFO_TOPIC` - write to topic
+> - `KAFKA_ERR_TOPIC` - error write to topic
+
+2. Run the scraper with `go run scraper/main/main.go`
+
+> For the insertes, make sure to set the following environment variables:
+> - `KAFKA_GROUPID`
+> - `KAFKA_NAME_TOPIC` - read from topic
+> - `KAFKA_INFO_TOPIC` - write to topic
+
+3. Run the dgraph inserter with `go run dgraph-inserter/main/main.go`
+3. Run the neo4j inserter with `go run neo4j-inserter/main/main.go`
+3. Run the postgres inserter with `go run postgres-inserter/main/main.go`
 
 If this is your first time running this:
 

--- a/dgraph-inserter/inserter.go
+++ b/dgraph-inserter/inserter.go
@@ -27,19 +27,19 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, dgraphAddress string) *Inserter {
+func New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic string) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
-		GroupID:        "user_dgraph_inserter",
-		Topic:          "user_follow_infos",
-		MinBytes:       10e3, // 10KB
-		MaxBytes:       10e6, // 10MB
+		GroupID:        groupID, //"user_dgraph_inserter",
+		Topic:          rTopic,  //"user_follow_infos",
+		MinBytes:       10e3,    // 10KB
+		MaxBytes:       10e6,    // 10MB
 		CommitInterval: time.Second,
 	})
 	i.qWriter = kafka.NewWriter(kafka.WriterConfig{
 		Brokers:  []string{kafkaAddress},
-		Topic:    "user_names",
+		Topic:    wTopic, //"user_names",
 		Balancer: &kafka.LeastBytes{},
 		Async:    true,
 	})

--- a/dgraph-inserter/inserter.go
+++ b/dgraph-inserter/inserter.go
@@ -27,20 +27,20 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic string, userDiscovery bool) *Inserter {
+func New(kafkaAddress, dgraphAddress string, kConfig *utils.KafkaConsumerConfig) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
-		GroupID:        groupID, //"user_dgraph_inserter",
-		Topic:          rTopic,  //"user_follow_infos",
-		MinBytes:       10e3,    // 10KB
-		MaxBytes:       10e6,    // 10MB
+		GroupID:        kConfig.GroupID, //"user_dgraph_inserter",
+		Topic:          kConfig.RTopic,  //"user_follow_infos",
+		MinBytes:       10e3,            // 10KB
+		MaxBytes:       10e6,            // 10MB
 		CommitInterval: time.Second,
 	})
-	if userDiscovery {
+	if kConfig.IsUserDiscovery {
 		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
 			Brokers:  []string{kafkaAddress},
-			Topic:    wTopic, //"user_names",
+			Topic:    kConfig.WTopic, //"user_names",
 			Balancer: &kafka.LeastBytes{},
 			Async:    true,
 		})

--- a/dgraph-inserter/inserter.go
+++ b/dgraph-inserter/inserter.go
@@ -27,7 +27,7 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic string) *Inserter {
+func New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic string, userDiscovery bool) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
@@ -37,12 +37,14 @@ func New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic string) *Inserter 
 		MaxBytes:       10e6,    // 10MB
 		CommitInterval: time.Second,
 	})
-	i.qWriter = kafka.NewWriter(kafka.WriterConfig{
-		Brokers:  []string{kafkaAddress},
-		Topic:    wTopic, //"user_names",
-		Balancer: &kafka.LeastBytes{},
-		Async:    true,
-	})
+	if userDiscovery {
+		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
+			Brokers:  []string{kafkaAddress},
+			Topic:    wTopic, //"user_names",
+			Balancer: &kafka.LeastBytes{},
+			Async:    true,
+		})
+	}
 	dg, conn := utils.GetDGraphClient(dgraphAddress)
 	i.dgClient = dg
 	i.dgConn = conn
@@ -83,7 +85,9 @@ func (i *Inserter) Close() {
 
 	i.dgConn.Close()
 	i.qReader.Close()
-	i.qWriter.Close()
+	if i.qWriter != nil {
+		i.qWriter.Close()
+	}
 
 	i.MarkAsClosed()
 }
@@ -145,7 +149,8 @@ func (i *Inserter) insertUser(p *models.User) {
 }
 
 func (i *Inserter) handleCreatedUser(userName, uid string, created bool) {
-	if created {
+	// if qWriter is nil, user discovery is disabled
+	if created && i.qWriter != nil {
 		i.qWriter.WriteMessages(context.Background(), kafka.Message{
 			Value: []byte(userName),
 		})

--- a/dgraph-inserter/inserter.go
+++ b/dgraph-inserter/inserter.go
@@ -27,24 +27,11 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, dgraphAddress string, kConfig *utils.KafkaConsumerConfig) *Inserter {
+func New(dgraphAddress string, qReader *kafka.Reader, qWriter *kafka.Writer) *Inserter {
 	i := &Inserter{}
-	i.qReader = kafka.NewReader(kafka.ReaderConfig{
-		Brokers:        []string{kafkaAddress},
-		GroupID:        kConfig.GroupID, //"user_dgraph_inserter",
-		Topic:          kConfig.RTopic,  //"user_follow_infos",
-		MinBytes:       10e3,            // 10KB
-		MaxBytes:       10e6,            // 10MB
-		CommitInterval: time.Second,
-	})
-	if kConfig.IsUserDiscovery {
-		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
-			Brokers:  []string{kafkaAddress},
-			Topic:    kConfig.WTopic, //"user_names",
-			Balancer: &kafka.LeastBytes{},
-			Async:    true,
-		})
-	}
+	i.qReader = qReader
+	i.qWriter = qWriter
+
 	dg, conn := utils.GetDGraphClient(dgraphAddress)
 	i.dgClient = dg
 	i.dgConn = conn

--- a/dgraph-inserter/main/main.go
+++ b/dgraph-inserter/main/main.go
@@ -7,11 +7,14 @@ import (
 )
 
 func main() {
+	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
+	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
+	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	dgraphAddress := utils.GetStringFromEnvWithDefault("DGRPAH_ADDRESS", "127.0.0.1:9080")
 
-	i := inserter.New(kafkaAddress, dgraphAddress)
+	i := inserter.New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/dgraph-inserter/main/main.go
+++ b/dgraph-inserter/main/main.go
@@ -10,11 +10,12 @@ func main() {
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
 	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
 	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
+	userDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	dgraphAddress := utils.GetStringFromEnvWithDefault("DGRPAH_ADDRESS", "127.0.0.1:9080")
 
-	i := inserter.New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic)
+	i := inserter.New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic, userDiscovery)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/dgraph-inserter/main/main.go
+++ b/dgraph-inserter/main/main.go
@@ -2,21 +2,36 @@ package main
 
 import (
 	inserter "github.com/codeuniversity/smag-mvp/dgraph-inserter"
+	"github.com/codeuniversity/smag-mvp/kafka"
 	"github.com/codeuniversity/smag-mvp/service"
 	"github.com/codeuniversity/smag-mvp/utils"
 )
 
 func main() {
-	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
-	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
-	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
-	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	var i *inserter.Inserter
 
-	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	dgraphAddress := utils.GetStringFromEnvWithDefault("DGRPAH_ADDRESS", "127.0.0.1:9080")
 
-	kafkaConfig := utils.NewKafkaConsumerConfig(groupID, rTopic, wTopic, isUserDiscovery)
-	i := inserter.New(kafkaAddress, dgraphAddress, kafkaConfig)
+	isUserDiscovery, err := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	if err != nil {
+		panic(err)
+	}
+
+	qReaderConfig, qWriterConfig := kafka.GetInserterConfig(isUserDiscovery)
+
+	if isUserDiscovery {
+		i = inserter.New(
+			dgraphAddress,
+			kafka.NewReader(qReaderConfig),
+			kafka.NewWriter(qWriterConfig),
+		)
+	} else {
+		i = inserter.New(
+			dgraphAddress,
+			kafka.NewReader(qReaderConfig),
+			nil,
+		)
+	}
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/dgraph-inserter/main/main.go
+++ b/dgraph-inserter/main/main.go
@@ -10,12 +10,13 @@ func main() {
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
 	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
 	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
-	userDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	dgraphAddress := utils.GetStringFromEnvWithDefault("DGRPAH_ADDRESS", "127.0.0.1:9080")
 
-	i := inserter.New(kafkaAddress, dgraphAddress, groupID, rTopic, wTopic, userDiscovery)
+	kafkaConfig := utils.NewKafkaConsumerConfig(groupID, rTopic, wTopic, isUserDiscovery)
+	i := inserter.New(kafkaAddress, dgraphAddress, kafkaConfig)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/dgraph-inserter/main/main.go
+++ b/dgraph-inserter/main/main.go
@@ -12,12 +12,7 @@ func main() {
 
 	dgraphAddress := utils.GetStringFromEnvWithDefault("DGRPAH_ADDRESS", "127.0.0.1:9080")
 
-	isUserDiscovery, err := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
-	if err != nil {
-		panic(err)
-	}
-
-	qReaderConfig, qWriterConfig := kafka.GetInserterConfig(isUserDiscovery)
+	qReaderConfig, qWriterConfig, isUserDiscovery := kafka.GetInserterConfig()
 
 	if isUserDiscovery {
 		i = inserter.New(

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/neo4j/neo4j-go-driver v1.7.4
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/segmentio/kafka-go v0.3.2
 	github.com/temoto/robotstxt v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/golang-migrate/migrate v3.5.4+incompatible/go.mod h1:IsVUlFN5puWOmXrq
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -91,6 +92,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c h1:+EXw7AwNOKzPFXMZ1yNjO40aWCh3PIquJB2fYlv9wcs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"time"
 
+	"github.com/codeuniversity/smag-mvp/utils"
 	"github.com/segmentio/kafka-go"
 )
 
@@ -52,4 +53,22 @@ func NewWriter(c *WriterConfig) *kafka.Writer {
 		Balancer: &kafka.LeastBytes{},
 		Async:    c.Async,
 	})
+}
+
+func GetInserterConfig(isUserDiscovery bool) (*ReaderConfig, *WriterConfig) {
+	var readerConfig *ReaderConfig
+	var writerConfig *WriterConfig
+	var wTopic string
+
+	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
+	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
+	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
+
+	if isUserDiscovery {
+		wTopic = utils.MustGetStringFromEnv("KAFKA_WTOPIC")
+		writerConfig = NewWriterConfig(kafkaAddress, wTopic, true)
+	}
+
+	readerConfig = NewReaderConfig(kafkaAddress, groupID, rTopic)
+	return readerConfig, writerConfig
 }

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -67,23 +67,24 @@ func NewWriter(c *WriterConfig) *kafka.Writer {
 
 // GetInserterConfig is a convenience function for gathering the necessary
 // kafka configuration for all inserters
-func GetInserterConfig(isUserDiscovery bool) (*ReaderConfig, *WriterConfig) {
+func GetInserterConfig() (*ReaderConfig, *WriterConfig, bool) {
 	var readerConfig *ReaderConfig
 	var writerConfig *WriterConfig
 	var wTopic string
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
+	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
-	rTopic := utils.MustGetStringFromEnv("KAFKA_R_TOPIC")
+	rTopic := utils.MustGetStringFromEnv("KAFKA_NAME_TOPIC")
 
 	if isUserDiscovery {
-		wTopic = utils.MustGetStringFromEnv("KAFKA_W_TOPIC")
+		wTopic = utils.MustGetStringFromEnv("KAFKA_INFO_TOPIC")
 		writerConfig = NewWriterConfig(kafkaAddress, wTopic, true)
 	}
 
 	readerConfig = NewReaderConfig(kafkaAddress, groupID, rTopic)
-	return readerConfig, writerConfig
+	return readerConfig, writerConfig, isUserDiscovery
 }
 
 // GetScraperConfig is a convenience function for gathering the necessary

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -1,0 +1,55 @@
+package kafka
+
+import (
+	"time"
+
+	"github.com/segmentio/kafka-go"
+)
+
+type ReaderConfig struct {
+	Address string
+	GroupID string
+	Topic   string
+}
+
+type WriterConfig struct {
+	Address string
+	Topic   string
+	Async   bool
+}
+
+func NewReaderConfig(kafkaAddress, groupID, topic string) *ReaderConfig {
+	return &ReaderConfig{
+		Address: kafkaAddress,
+		GroupID: groupID,
+		Topic:   topic,
+	}
+}
+
+func NewWriterConfig(kafkaAddress, topic string, async bool) *WriterConfig {
+	return &WriterConfig{
+		Address: kafkaAddress,
+		Topic:   topic,
+		Async:   async,
+	}
+}
+
+func NewReader(c *ReaderConfig) *kafka.Reader {
+	return kafka.NewReader(kafka.ReaderConfig{
+		Brokers:        []string{c.Address},
+		GroupID:        c.GroupID,
+		Topic:          c.Topic,
+		MinBytes:       10e3, // 10KB
+		MaxBytes:       10e6, // 10MB
+		CommitInterval: time.Second,
+	})
+}
+
+func NewWriter(c *WriterConfig) *kafka.Writer {
+	return kafka.NewWriter(kafka.WriterConfig{
+		Brokers:  []string{c.Address},
+		Topic:    c.Topic,
+		Balancer: &kafka.LeastBytes{},
+		Async:    c.Async,
+	})
+}

--- a/neo4j-inserter/inserter.go
+++ b/neo4j-inserter/inserter.go
@@ -23,19 +23,19 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword string) *Inserter {
+func New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, groupID, rTopic, wTopic string) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
-		GroupID:        "user_neo4j_inserter",
-		Topic:          "user_follow_infos",
-		MinBytes:       10e3, // 10KB
-		MaxBytes:       10e6, // 10MB
+		GroupID:        groupID, //"user_neo4j_inserter",
+		Topic:          rTopic,  //"user_follow_infos",
+		MinBytes:       10e3,    // 10KB
+		MaxBytes:       10e6,    // 10MB
 		CommitInterval: time.Second,
 	})
 	i.qWriter = kafka.NewWriter(kafka.WriterConfig{
 		Brokers:  []string{kafkaAddress},
-		Topic:    "user_names",
+		Topic:    wTopic, //"user_names",
 		Balancer: &kafka.LeastBytes{},
 		Async:    true,
 	})

--- a/neo4j-inserter/inserter.go
+++ b/neo4j-inserter/inserter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/codeuniversity/smag-mvp/utils"
+
 	"github.com/codeuniversity/smag-mvp/models"
 	"github.com/codeuniversity/smag-mvp/service"
 	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
@@ -23,20 +25,20 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, groupID, rTopic, wTopic string, userDiscovery bool) *Inserter {
+func New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword string, kConfig *utils.KafkaConsumerConfig) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
-		GroupID:        groupID, //"user_neo4j_inserter",
-		Topic:          rTopic,  //"user_follow_infos",
-		MinBytes:       10e3,    // 10KB
-		MaxBytes:       10e6,    // 10MB
+		GroupID:        kConfig.GroupID, //"user_neo4j_inserter",
+		Topic:          kConfig.RTopic,  //"user_follow_infos",
+		MinBytes:       10e3,            // 10KB
+		MaxBytes:       10e6,            // 10MB
 		CommitInterval: time.Second,
 	})
-	if userDiscovery {
+	if kConfig.IsUserDiscovery {
 		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
 			Brokers:  []string{kafkaAddress},
-			Topic:    wTopic, //"user_names",
+			Topic:    kConfig.WTopic, //"user_names",
 			Balancer: &kafka.LeastBytes{},
 			Async:    true,
 		})

--- a/neo4j-inserter/inserter.go
+++ b/neo4j-inserter/inserter.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/codeuniversity/smag-mvp/utils"
-
 	"github.com/codeuniversity/smag-mvp/models"
 	"github.com/codeuniversity/smag-mvp/service"
 	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
@@ -25,24 +23,10 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword string, kConfig *utils.KafkaConsumerConfig) *Inserter {
+func New(neo4jAddress, neo4jUsername, neo4jPassword string, qReader *kafka.Reader, qWriter *kafka.Writer) *Inserter {
 	i := &Inserter{}
-	i.qReader = kafka.NewReader(kafka.ReaderConfig{
-		Brokers:        []string{kafkaAddress},
-		GroupID:        kConfig.GroupID, //"user_neo4j_inserter",
-		Topic:          kConfig.RTopic,  //"user_follow_infos",
-		MinBytes:       10e3,            // 10KB
-		MaxBytes:       10e6,            // 10MB
-		CommitInterval: time.Second,
-	})
-	if kConfig.IsUserDiscovery {
-		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
-			Brokers:  []string{kafkaAddress},
-			Topic:    kConfig.WTopic, //"user_names",
-			Balancer: &kafka.LeastBytes{},
-			Async:    true,
-		})
-	}
+	i.qReader = qReader
+	i.qWriter = qWriter
 
 	i.initializeNeo4j(neo4jUsername, neo4jPassword, neo4jAddress)
 

--- a/neo4j-inserter/main/main.go
+++ b/neo4j-inserter/main/main.go
@@ -10,13 +10,14 @@ func main() {
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
 	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
 	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
+	userDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	neo4jAddress := utils.GetStringFromEnvWithDefault("NEO4J_ADDRESS", "127.0.0.1:7687")
 	neo4jUsername := utils.GetStringFromEnvWithDefault("NEO4J_USERNAME", "neo4j")
 	neo4jPassword := utils.GetStringFromEnvWithDefault("NEO4J_PASSWORD", "123456")
 
-	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, groupID, rTopic, wTopic)
+	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, groupID, rTopic, wTopic, userDiscovery)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/neo4j-inserter/main/main.go
+++ b/neo4j-inserter/main/main.go
@@ -1,24 +1,43 @@
 package main
 
 import (
+	"github.com/codeuniversity/smag-mvp/kafka"
 	inserter "github.com/codeuniversity/smag-mvp/neo4j-inserter"
 	"github.com/codeuniversity/smag-mvp/service"
 	"github.com/codeuniversity/smag-mvp/utils"
 )
 
 func main() {
-	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
-	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
-	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
-	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	var i *inserter.Inserter
 
-	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	neo4jAddress := utils.GetStringFromEnvWithDefault("NEO4J_ADDRESS", "127.0.0.1:7687")
 	neo4jUsername := utils.GetStringFromEnvWithDefault("NEO4J_USERNAME", "neo4j")
 	neo4jPassword := utils.GetStringFromEnvWithDefault("NEO4J_PASSWORD", "123456")
 
-	kafkaConfig := utils.NewKafkaConsumerConfig(groupID, rTopic, wTopic, isUserDiscovery)
-	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, kafkaConfig)
+	isUserDiscovery, err := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	if err != nil {
+		panic(err)
+	}
+
+	qReaderConfig, qWriterConfig := kafka.GetInserterConfig(isUserDiscovery)
+
+	if isUserDiscovery {
+		i = inserter.New(
+			neo4jAddress,
+			neo4jUsername,
+			neo4jPassword,
+			kafka.NewReader(qReaderConfig),
+			kafka.NewWriter(qWriterConfig),
+		)
+	} else {
+		i = inserter.New(
+			neo4jAddress,
+			neo4jUsername,
+			neo4jPassword,
+			kafka.NewReader(qReaderConfig),
+			nil,
+		)
+	}
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/neo4j-inserter/main/main.go
+++ b/neo4j-inserter/main/main.go
@@ -14,12 +14,7 @@ func main() {
 	neo4jUsername := utils.GetStringFromEnvWithDefault("NEO4J_USERNAME", "neo4j")
 	neo4jPassword := utils.GetStringFromEnvWithDefault("NEO4J_PASSWORD", "123456")
 
-	isUserDiscovery, err := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
-	if err != nil {
-		panic(err)
-	}
-
-	qReaderConfig, qWriterConfig := kafka.GetInserterConfig(isUserDiscovery)
+	qReaderConfig, qWriterConfig, isUserDiscovery := kafka.GetInserterConfig()
 
 	if isUserDiscovery {
 		i = inserter.New(

--- a/neo4j-inserter/main/main.go
+++ b/neo4j-inserter/main/main.go
@@ -7,13 +7,16 @@ import (
 )
 
 func main() {
+	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
+	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
+	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	neo4jAddress := utils.GetStringFromEnvWithDefault("NEO4J_ADDRESS", "127.0.0.1:7687")
 	neo4jUsername := utils.GetStringFromEnvWithDefault("NEO4J_USERNAME", "neo4j")
 	neo4jPassword := utils.GetStringFromEnvWithDefault("NEO4J_PASSWORD", "123456")
 
-	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword)
+	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, groupID, rTopic, wTopic)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/neo4j-inserter/main/main.go
+++ b/neo4j-inserter/main/main.go
@@ -10,14 +10,15 @@ func main() {
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
 	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
 	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
-	userDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	neo4jAddress := utils.GetStringFromEnvWithDefault("NEO4J_ADDRESS", "127.0.0.1:7687")
 	neo4jUsername := utils.GetStringFromEnvWithDefault("NEO4J_USERNAME", "neo4j")
 	neo4jPassword := utils.GetStringFromEnvWithDefault("NEO4J_PASSWORD", "123456")
 
-	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, groupID, rTopic, wTopic, userDiscovery)
+	kafkaConfig := utils.NewKafkaConsumerConfig(groupID, rTopic, wTopic, isUserDiscovery)
+	i := inserter.New(kafkaAddress, neo4jAddress, neo4jUsername, neo4jPassword, kafkaConfig)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/postgres-inserter/inserter.go
+++ b/postgres-inserter/inserter.go
@@ -26,24 +26,11 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic string, userDiscovery bool) *Inserter {
+func New(kafkaAddress, postgresHost, postgresPassword string, qReader *kafka.Reader, qWriter *kafka.Writer) *Inserter {
 	i := &Inserter{}
-	i.qReader = kafka.NewReader(kafka.ReaderConfig{
-		Brokers:        []string{kafkaAddress},
-		GroupID:        groupID, //"user_postgres_inserter",
-		Topic:          rTopic,  //"user_follow_infos",
-		MinBytes:       10e3,    // 10KB
-		MaxBytes:       10e6,    // 10MB
-		CommitInterval: time.Second,
-	})
-	if userDiscovery {
-		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
-			Brokers:  []string{kafkaAddress},
-			Topic:    wTopic, //"user_names",
-			Balancer: &kafka.LeastBytes{},
-			Async:    true,
-		})
-	}
+	i.qReader = qReader
+	i.qWriter = qWriter
+
 	connectionString := fmt.Sprintf("host=%s user=postgres dbname=instascraper sslmode=disable", postgresHost)
 	if postgresPassword != "" {
 		connectionString += " " + "password=" + postgresPassword

--- a/postgres-inserter/inserter.go
+++ b/postgres-inserter/inserter.go
@@ -26,7 +26,7 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, postgresHost, postgresPassword string, qReader *kafka.Reader, qWriter *kafka.Writer) *Inserter {
+func New(postgresHost, postgresPassword string, qReader *kafka.Reader, qWriter *kafka.Writer) *Inserter {
 	i := &Inserter{}
 	i.qReader = qReader
 	i.qWriter = qWriter

--- a/postgres-inserter/inserter.go
+++ b/postgres-inserter/inserter.go
@@ -26,7 +26,7 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic string) *Inserter {
+func New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic string, userDiscovery bool) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
@@ -36,12 +36,14 @@ func New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic s
 		MaxBytes:       10e6,    // 10MB
 		CommitInterval: time.Second,
 	})
-	i.qWriter = kafka.NewWriter(kafka.WriterConfig{
-		Brokers:  []string{kafkaAddress},
-		Topic:    wTopic, //"user_names",
-		Balancer: &kafka.LeastBytes{},
-		Async:    true,
-	})
+	if userDiscovery {
+		i.qWriter = kafka.NewWriter(kafka.WriterConfig{
+			Brokers:  []string{kafkaAddress},
+			Topic:    wTopic, //"user_names",
+			Balancer: &kafka.LeastBytes{},
+			Async:    true,
+		})
+	}
 	connectionString := fmt.Sprintf("host=%s user=postgres dbname=instascraper sslmode=disable", postgresHost)
 	if postgresPassword != "" {
 		connectionString += " " + "password=" + postgresPassword
@@ -90,7 +92,9 @@ func (i *Inserter) Close() {
 
 	i.db.Close()
 	i.qReader.Close()
-	i.qWriter.Close()
+	if i.qWriter != nil {
+		i.qWriter.Close()
+	}
 
 	i.MarkAsClosed()
 }
@@ -146,7 +150,10 @@ func (i *Inserter) insertUser(p *models.User) {
 }
 
 func (i *Inserter) handleCreatedUser(userName string) {
-	i.qWriter.WriteMessages(context.Background(), kafka.Message{
-		Value: []byte(userName),
-	})
+	// if qWriter is nil, user discovery is disabled
+	if i.qWriter != nil {
+		i.qWriter.WriteMessages(context.Background(), kafka.Message{
+			Value: []byte(userName),
+		})
+	}
 }

--- a/postgres-inserter/inserter.go
+++ b/postgres-inserter/inserter.go
@@ -26,19 +26,19 @@ type Inserter struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress, postgresHost, postgresPassword string) *Inserter {
+func New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic string) *Inserter {
 	i := &Inserter{}
 	i.qReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        []string{kafkaAddress},
-		GroupID:        "user_postgres_inserter",
-		Topic:          "user_follow_infos",
-		MinBytes:       10e3, // 10KB
-		MaxBytes:       10e6, // 10MB
+		GroupID:        groupID, //"user_postgres_inserter",
+		Topic:          rTopic,  //"user_follow_infos",
+		MinBytes:       10e3,    // 10KB
+		MaxBytes:       10e6,    // 10MB
 		CommitInterval: time.Second,
 	})
 	i.qWriter = kafka.NewWriter(kafka.WriterConfig{
 		Brokers:  []string{kafkaAddress},
-		Topic:    "user_names",
+		Topic:    wTopic, //"user_names",
 		Balancer: &kafka.LeastBytes{},
 		Async:    true,
 	})

--- a/postgres-inserter/main/main.go
+++ b/postgres-inserter/main/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/codeuniversity/smag-mvp/kafka"
 	inserter "github.com/codeuniversity/smag-mvp/postgres-inserter"
 	"github.com/codeuniversity/smag-mvp/service"
 	"github.com/codeuniversity/smag-mvp/utils"
@@ -10,13 +11,22 @@ func main() {
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
 	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
 	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
-	userDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	postgresHost := utils.GetStringFromEnvWithDefault("POSTGRES_HOST", "127.0.0.1")
 	postgresPassword := utils.GetStringFromEnvWithDefault("POSTGRES_PASSWORD", "")
 
-	i := inserter.New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic, userDiscovery)
+	qReaderConfig := kafka.NewReaderConfig(kafkaAddress, groupID, topic)
+	qWriterConfig := kafka.NewWriterConfig(kafkaAddress, topic, true)
+
+	i := inserter.New(
+		kafkaAddress,
+		postgresHost,
+		postgresPassword,
+		kafka.NewReader(qReaderConfig),
+		kafka.NewWriter(qWriterConfig),
+	)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/postgres-inserter/main/main.go
+++ b/postgres-inserter/main/main.go
@@ -13,12 +13,7 @@ func main() {
 	postgresHost := utils.GetStringFromEnvWithDefault("POSTGRES_HOST", "127.0.0.1")
 	postgresPassword := utils.GetStringFromEnvWithDefault("POSTGRES_PASSWORD", "")
 
-	isUserDiscovery, err := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
-	if err != nil {
-		panic(err)
-	}
-
-	qReaderConfig, qWriterConfig := kafka.GetInserterConfig(isUserDiscovery)
+	qReaderConfig, qWriterConfig, isUserDiscovery := kafka.GetInserterConfig()
 
 	if isUserDiscovery {
 		i = inserter.New(

--- a/postgres-inserter/main/main.go
+++ b/postgres-inserter/main/main.go
@@ -7,12 +7,15 @@ import (
 )
 
 func main() {
+	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
+	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
+	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	postgresHost := utils.GetStringFromEnvWithDefault("POSTGRES_HOST", "127.0.0.1")
 	postgresPassword := utils.GetStringFromEnvWithDefault("POSTGRES_PASSWORD", "")
 
-	i := inserter.New(kafkaAddress, postgresHost, postgresPassword)
+	i := inserter.New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/postgres-inserter/main/main.go
+++ b/postgres-inserter/main/main.go
@@ -10,12 +10,13 @@ func main() {
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
 	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
 	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
+	userDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	postgresHost := utils.GetStringFromEnvWithDefault("POSTGRES_HOST", "127.0.0.1")
 	postgresPassword := utils.GetStringFromEnvWithDefault("POSTGRES_PASSWORD", "")
 
-	i := inserter.New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic)
+	i := inserter.New(kafkaAddress, postgresHost, postgresPassword, groupID, rTopic, wTopic, userDiscovery)
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/postgres-inserter/main/main.go
+++ b/postgres-inserter/main/main.go
@@ -8,25 +8,33 @@ import (
 )
 
 func main() {
-	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
-	rTopic := utils.MustGetStringFromEnv("KAFKA_RTOPIC")
-	wTopic := utils.MustGetStringFromEnv("KAFKA_WTOPIC")
-	isUserDiscovery := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	var i *inserter.Inserter
 
-	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 	postgresHost := utils.GetStringFromEnvWithDefault("POSTGRES_HOST", "127.0.0.1")
 	postgresPassword := utils.GetStringFromEnvWithDefault("POSTGRES_PASSWORD", "")
 
-	qReaderConfig := kafka.NewReaderConfig(kafkaAddress, groupID, topic)
-	qWriterConfig := kafka.NewWriterConfig(kafkaAddress, topic, true)
+	isUserDiscovery, err := utils.GetBoolFromEnvWithDefault("USER_DISCOVERY", false)
+	if err != nil {
+		panic(err)
+	}
 
-	i := inserter.New(
-		kafkaAddress,
-		postgresHost,
-		postgresPassword,
-		kafka.NewReader(qReaderConfig),
-		kafka.NewWriter(qWriterConfig),
-	)
+	qReaderConfig, qWriterConfig := kafka.GetInserterConfig(isUserDiscovery)
+
+	if isUserDiscovery {
+		i = inserter.New(
+			postgresHost,
+			postgresPassword,
+			kafka.NewReader(qReaderConfig),
+			kafka.NewWriter(qWriterConfig),
+		)
+	} else {
+		i = inserter.New(
+			postgresHost,
+			postgresPassword,
+			kafka.NewReader(qReaderConfig),
+			nil,
+		)
+	}
 
 	service.CloseOnSignal(i)
 	go i.Run()

--- a/scraper/main/main.go
+++ b/scraper/main/main.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"github.com/codeuniversity/smag-mvp/kafka"
 	"github.com/codeuniversity/smag-mvp/scraper"
 	"github.com/codeuniversity/smag-mvp/service"
-	"github.com/codeuniversity/smag-mvp/utils"
 )
 
 func main() {
-	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
+	nameReaderConfig, infoWriterConfig, errWriterConfig := kafka.GetScraperConfig()
 
-	s := scraper.New(kafkaAddress)
+	s := scraper.New(
+		kafka.NewReader(nameReaderConfig),
+		kafka.NewWriter(infoWriterConfig),
+		kafka.NewWriter(errWriterConfig),
+	)
 	service.CloseOnSignal(s)
 	go s.Run()
 

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -24,26 +24,11 @@ type Scraper struct {
 }
 
 // New returns an initilized scraper
-func New(kafkaAddress string) *Scraper {
+func New(nameQReader *kafka.Reader, infoQWriter *kafka.Writer, errQWriter *kafka.Writer) *Scraper {
 	s := &Scraper{}
-	s.nameQReader = kafka.NewReader(kafka.ReaderConfig{
-		Brokers:        []string{kafkaAddress},
-		GroupID:        "user_follow_graph_scraper",
-		Topic:          "user_names",
-		CommitInterval: time.Second,
-	})
-	s.infoQWriter = kafka.NewWriter(kafka.WriterConfig{
-		Brokers:  []string{kafkaAddress},
-		Topic:    "user_follow_infos",
-		Balancer: &kafka.LeastBytes{},
-		Async:    true,
-	})
-	s.errQWriter = kafka.NewWriter(kafka.WriterConfig{
-		Brokers:  []string{kafkaAddress},
-		Topic:    "user_scrape_errors",
-		Balancer: &kafka.LeastBytes{},
-		Async:    false,
-	})
+	s.nameQReader = nameQReader
+	s.infoQWriter = infoQWriter
+	s.errQWriter = errQWriter
 	s.Executor = service.New()
 	return s
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -46,3 +46,13 @@ func GetStringFromEnvWithDefault(enVarName, defaultValue string) string {
 
 	return envValue
 }
+
+//MustGetStringFromEnv panics if OS Enviroment Variable is not set
+func MustGetStringFromEnv(enVarName string) string {
+	envValue := os.Getenv(enVarName)
+	if envValue == "" {
+		panic(fmt.Sprintf("%s must not be empty", enVarName))
+	}
+
+	return envValue
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/dgraph-io/dgo"
@@ -37,7 +38,7 @@ func WithRetries(times int, f func() error) error {
 	return err
 }
 
-//GetStringFromEnvWithDefault returns default Value if OS Enviroment Variable is not set
+//GetStringFromEnvWithDefault returns default Value if OS Environment Variable is not set
 func GetStringFromEnvWithDefault(enVarName, defaultValue string) string {
 	envValue := os.Getenv(enVarName)
 	if envValue == "" {
@@ -47,7 +48,7 @@ func GetStringFromEnvWithDefault(enVarName, defaultValue string) string {
 	return envValue
 }
 
-//MustGetStringFromEnv panics if OS Enviroment Variable is not set
+//MustGetStringFromEnv panics if OS Environment Variable is not set
 func MustGetStringFromEnv(enVarName string) string {
 	envValue := os.Getenv(enVarName)
 	if envValue == "" {
@@ -55,4 +56,15 @@ func MustGetStringFromEnv(enVarName string) string {
 	}
 
 	return envValue
+}
+
+// GetBoolFromEnvWithDefault parses an OS Environment Variable as bool
+func GetBoolFromEnvWithDefault(enVarName string, defaultValue bool) bool {
+	envValue := os.Getenv(enVarName)
+	envBool, err := strconv.ParseBool(envValue)
+	if err != nil {
+		return defaultValue
+	}
+
+	return envBool
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,16 +59,16 @@ func MustGetStringFromEnv(enVarName string) string {
 }
 
 // GetBoolFromEnvWithDefault parses an OS Environment Variable as bool
-func GetBoolFromEnvWithDefault(enVarName string, defaultValue bool) (bool, error) {
+func GetBoolFromEnvWithDefault(enVarName string, defaultValue bool) bool {
 	envValue := os.Getenv(enVarName)
 	if envValue == "" {
-		return defaultValue, nil
+		return defaultValue
 	}
 
 	envBool, err := strconv.ParseBool(envValue)
 	if err != nil {
-		return defaultValue, err
+		panic(fmt.Errorf("couldn't parse %s as bool: %s", enVarName, err))
 	}
 
-	return envBool, nil
+	return envBool
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,12 +59,16 @@ func MustGetStringFromEnv(enVarName string) string {
 }
 
 // GetBoolFromEnvWithDefault parses an OS Environment Variable as bool
-func GetBoolFromEnvWithDefault(enVarName string, defaultValue bool) bool {
+func GetBoolFromEnvWithDefault(enVarName string, defaultValue bool) (bool, error) {
 	envValue := os.Getenv(enVarName)
-	envBool, err := strconv.ParseBool(envValue)
-	if err != nil {
-		return defaultValue
+	if envValue == "" {
+		return defaultValue, nil
 	}
 
-	return envBool
+	envBool, err := strconv.ParseBool(envValue)
+	if err != nil {
+		return defaultValue, err
+	}
+
+	return envBool, nil
 }


### PR DESCRIPTION
- make groupID, topics configurable via environment variables
- add `USER_DISCOVERY` env variable (`true|false`) for setting which inserter inserts new user names into the `user_names` topic
- refactor configuration using `utils.KafkaConsumerConfig` structure