### PR TITLE
Fix/insta posts inserter

### DIFF
--- a/insta_posts-inserter/main/main.go
+++ b/insta_posts-inserter/main/main.go
@@ -14,7 +14,7 @@ func main() {
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
 
 	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
-	rTopic := utils.MustGetStringFromEnv("KAFKA_NAME_TOPIC")
+	rTopic := utils.MustGetStringFromEnv("KAFKA_INSTA_POSTS_TOPIC")
 	qReaderConfig := kafka.NewReaderConfig(kafkaAddress, groupID, rTopic)
 
 	i := inserter.New(postgresHost, postgresPassword, kafka.NewReader(qReaderConfig))

--- a/insta_posts-scraper/main/main.go
+++ b/insta_posts-scraper/main/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	nameReaderConfig, infoWriterConfig, errWriterConfig := kafka.GetScraperConfig()
+	nameReaderConfig, infoWriterConfig, errWriterConfig := kafka.GetInstaPostsScraperConfig()
 
 	s := scraper.New(kafka.NewReader(nameReaderConfig), kafka.NewWriter(infoWriterConfig), kafka.NewWriter(errWriterConfig))
 

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -121,3 +121,24 @@ func GetScraperConfig() (*ReaderConfig, *WriterConfig, *WriterConfig) {
 
 	return nameReaderConfig, infoWriterConfig, errWriterConfig
 }
+
+// GetInstaPostsScraperConfig is a convenience function for gathering the necessary
+// kafka configuration for the insta posts golang scrapers
+func GetInstaPostsScraperConfig() (*ReaderConfig, *WriterConfig, *WriterConfig) {
+	var nameReaderConfig *ReaderConfig
+	var infoWriterConfig *WriterConfig
+	var errWriterConfig *WriterConfig
+
+	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "127.0.0.1:9092")
+
+	groupID := utils.MustGetStringFromEnv("KAFKA_GROUPID")
+	nameTopic := utils.MustGetStringFromEnv("KAFKA_NAME_TOPIC")
+	postsTopic := utils.MustGetStringFromEnv("KAFKA_INSTA_POSTS_TOPIC")
+	errTopic := utils.MustGetStringFromEnv("KAFKA_ERR_TOPIC")
+
+	nameReaderConfig = NewReaderConfig(kafkaAddress, groupID, nameTopic)
+	infoWriterConfig = NewWriterConfig(kafkaAddress, postsTopic, true)
+	errWriterConfig = NewWriterConfig(kafkaAddress, errTopic, false)
+
+	return nameReaderConfig, infoWriterConfig, errWriterConfig
+}


### PR DESCRIPTION
# Description

This PR fixes the bug that the insta_posts_scraper was writing to `user_follow_infos` and insta_posts-inserter was reading from it. This caused the inserter to crash as the `user_follow_infos` was intended to hold  the information of a user.
The  insta_posts_scraper is now writing into `user_post` and  insta_posts-inserter is reading from it.

Fixes #52 
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [X] Run on local machine

