### PR TITLE
Add dockerfile to cli, refactor cli to use env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If this is your first time running this:
 
 1. Add `127.0.0.1 my-kafka` to your `/etc/hosts` file
 2. Run `make init-db`, to set the postgres-db up
-3. Choose a user_name as a starting point and run `go run cli/main/main.go <user_name>`
+3. Choose a user_name as a starting point and run `go run cli/main/main.go instagram <user_name>`
 
 ### scraper in docker
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.13 as builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . . 
+RUN CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o smag-cli cli/main/main.go
+
+FROM alpine
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+COPY --from=builder /app/smag-cli .
+CMD ["./smag-cli"]

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -15,7 +15,7 @@ func main() {
 	var userNameArg string
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "my-kafka:9092")
-	instagramTopic := utils.GetStringFromEnvWithDefault("INSTAGRAM_TOPIC", "user_names")
+	instagramTopic := utils.GetStringFromEnvWithDefault("KAFKA_INSTAGRAM_TOPIC", "user_names")
 	twitterTopic := utils.GetStringFromEnvWithDefault("TWITTER_TOPIC", "twitter-user_names")
 
 	if len(os.Args) == 3 {

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -11,21 +11,30 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 3 {
-		fmt.Println("Usage: go run cli/main/main.go <instagram|twitter> <username>")
-		return
-	}
+	var platformArg string
+	var userNameArg string
 
-	platformArg := os.Args[1]
-	userNameArg := os.Args[2]
+	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "my-kafka:9092")
+	instagramTopic := utils.GetStringFromEnvWithDefault("INSTAGRAM_TOPIC", "user_names")
+	twitterTopic := utils.GetStringFromEnvWithDefault("Twitter_TOPIC", "twitter-user_names")
+
+	if len(os.Args) == 3 {
+		fmt.Println("getting arguments from parameters")
+		platformArg = os.Args[1]
+		userNameArg = os.Args[2]
+	} else {
+		fmt.Println("getting arguments from env variables")
+		platformArg = utils.MustGetStringFromEnv("CLI_PLATFORM")
+		userNameArg = utils.MustGetStringFromEnv("CLI_USER")
+	}
 
 	var topic string
 	switch platformArg {
 	case "instagram":
-		topic = "user_names"
+		topic = instagramTopic
 		break
 	case "twitter":
-		topic = "twitter-user_names"
+		topic = twitterTopic
 		break
 	default:
 		fmt.Printf("Invalid platform option: %s\n", platformArg)
@@ -33,7 +42,7 @@ func main() {
 	}
 
 	w := kafka.NewWriter(kafka.WriterConfig{
-		Brokers:  []string{"localhost:9092"},
+		Brokers:  []string{kafkaAddress},
 		Topic:    topic,
 		Balancer: &kafka.LeastBytes{},
 	})

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "my-kafka:9092")
 	instagramTopic := utils.GetStringFromEnvWithDefault("INSTAGRAM_TOPIC", "user_names")
-	twitterTopic := utils.GetStringFromEnvWithDefault("Twitter_TOPIC", "twitter-user_names")
+	twitterTopic := utils.GetStringFromEnvWithDefault("TWITTER_TOPIC", "twitter-user_names")
 
 	if len(os.Args) == 3 {
 		fmt.Println("getting arguments from parameters")

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "my-kafka:9092")
 	instagramTopic := utils.GetStringFromEnvWithDefault("KAFKA_INSTAGRAM_TOPIC", "user_names")
-	twitterTopic := utils.GetStringFromEnvWithDefault("TWITTER_TOPIC", "twitter-user_names")
+	twitterTopic := utils.GetStringFromEnvWithDefault("KAFKA_TWITTER_TOPIC", "twitter-user_names")
 
 	if len(os.Args) == 3 {
 		fmt.Println("getting arguments from parameters")


### PR DESCRIPTION
# Description

In order to deploy the cli to Kubernetes, we need to build a docker image for that. In this PR, I added the necessary `Dockerfile` and refactored the `cli/main/main.go` to use env variables as an alternative besides command arguments and made it more configurable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Cleanup (changes in structure but not functionality)
