### PR TITLE
Refactor cli to use entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ If this is your first time running this:
 1. Add `127.0.0.1 my-kafka` and `127.0.0.1 minio` to your `/etc/hosts` file
 2. Choose a user_name as a starting point and run `go run cli/main/main.go <instagram|twitter> <user_name>`
 
+As alternative, you can also add the cli to the docker-compose:
+
+```yaml
+ cli:
+   build:
+     context: "."
+     dockerfile: "cli/Dockerfile"
+   command: ["<instagram|twitter>", "<user_name>"]
+   depends_on:
+     - "my-kafka"
+   environment:
+     KAFKA_ADDRESS: "my-kafka:9092"
+```
+
 ### scraper in docker
 
 ```bash

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -10,4 +10,4 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /app
 COPY --from=builder /app/smag-cli .
 ENTRYPOINT ["./smag-cli"]
-CMD [ "" ]
+CMD [ "" ] # optional explicit statement

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -9,4 +9,5 @@ FROM alpine
 RUN apk --no-cache add ca-certificates
 WORKDIR /app
 COPY --from=builder /app/smag-cli .
-CMD ["./smag-cli"]
+ENTRYPOINT ["./smag-cli"]
+CMD [ "" ]

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
 	"time"
 
@@ -11,22 +11,16 @@ import (
 )
 
 func main() {
-	var platformArg string
-	var userNameArg string
-
 	kafkaAddress := utils.GetStringFromEnvWithDefault("KAFKA_ADDRESS", "my-kafka:9092")
 	instagramTopic := utils.GetStringFromEnvWithDefault("KAFKA_INSTAGRAM_TOPIC", "user_names")
 	twitterTopic := utils.GetStringFromEnvWithDefault("KAFKA_TWITTER_TOPIC", "twitter-user_names")
 
-	if len(os.Args) == 3 {
-		log.Println("getting arguments from parameters")
-		platformArg = os.Args[1]
-		userNameArg = os.Args[2]
-	} else {
-		log.Println("getting arguments from env variables")
-		platformArg = utils.MustGetStringFromEnv("CLI_PLATFORM")
-		userNameArg = utils.MustGetStringFromEnv("CLI_USER")
+	if len(os.Args) < 3 {
+		panic("Invalid argumemts. Usage: cli <instagram|twitter> <username>")
 	}
+
+	platformArg := os.Args[1]
+	userNameArg := os.Args[2]
 
 	var topic string
 	switch platformArg {
@@ -37,8 +31,7 @@ func main() {
 		topic = twitterTopic
 		break
 	default:
-		log.Printf("Invalid platform option: %s\n", platformArg)
-		return
+		panic(fmt.Sprintf("Invalid platform option: %s\n", platformArg))
 	}
 
 	w := kafka.NewWriter(kafka.WriterConfig{


### PR DESCRIPTION
# Description

Refactors cli to use mainly command arguments instead of env variables while leaving `KAFKA_ADDRESS`, `KAFKA_INSTAGRAM_TOPIC` and `KAFKA_TWITTER_TOPIC` for configuration purposes.  Implements the support for command arguments in the docker image.

Fixes #82 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Cleanup (changes in structure but not functionality)
