### PR TITLE
walj2json to replace the default debezium plugin decoderbufs

### DIFF
--- a/debezium/kubernetes/kube-register-postgres.json
+++ b/debezium/kubernetes/kube-register-postgres.json
@@ -1,6 +1,7 @@
 {
   "name": "inventory-connector",
   "config": {
+    "plugin.name": "wal2json",
     "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
     "tasks.max": "1",
     "database.hostname": "my-postgres-postgresql",


### PR DESCRIPTION
# Description

Amazon RDS doesnt support the default debezium plugin decoderbuf. Wal2json is an output plugin which is in Amazon RDS Postgres integrated for logical decoding.  

Fixes #69 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested on the kubernetes cluster 

