### PR TITLE
Feature/scraper timeout environment variables

### DIFF
--- a/insta_comments-scraper/main/main.go
+++ b/insta_comments-scraper/main/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	scraper "github.com/codeuniversity/smag-mvp/insta_comments-scraper"
 	"github.com/codeuniversity/smag-mvp/kafka"
+	client "github.com/codeuniversity/smag-mvp/scraper-client"
 	"github.com/codeuniversity/smag-mvp/service"
 	"github.com/codeuniversity/smag-mvp/utils"
 )
@@ -11,7 +12,8 @@ func main() {
 	awsServiceAddress := utils.GetStringFromEnvWithDefault("AWS_SERVICE_ADDRESS", "")
 	readerConfig, infoWriterConfig, errWriterConfig := kafka.GetScraperConfig()
 
-	s := scraper.New(awsServiceAddress, kafka.NewReader(readerConfig), kafka.NewWriter(infoWriterConfig), kafka.NewWriter(errWriterConfig))
+	config := client.GetScraperConfig()
+	s := scraper.New(config, awsServiceAddress, kafka.NewReader(readerConfig), kafka.NewWriter(infoWriterConfig), kafka.NewWriter(errWriterConfig))
 
 	service.CloseOnSignal(s)
 	waitUntilClosed := s.Start()

--- a/insta_posts-scraper/main/main.go
+++ b/insta_posts-scraper/main/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	scraper "github.com/codeuniversity/smag-mvp/insta_posts-scraper"
 	"github.com/codeuniversity/smag-mvp/kafka"
+	client "github.com/codeuniversity/smag-mvp/scraper-client"
 	"github.com/codeuniversity/smag-mvp/service"
 	"github.com/codeuniversity/smag-mvp/utils"
 )
@@ -11,7 +12,8 @@ func main() {
 	awsServiceAddress := utils.GetStringFromEnvWithDefault("AWS_SERVICE_ADDRESS", "")
 	nameReaderConfig, infoWriterConfig, errWriterConfig := kafka.GetInstaPostsScraperConfig()
 
-	s := scraper.New(awsServiceAddress, kafka.NewReader(nameReaderConfig), kafka.NewWriter(infoWriterConfig), kafka.NewWriter(errWriterConfig))
+	config := client.GetScraperConfig()
+	s := scraper.New(config, awsServiceAddress, kafka.NewReader(nameReaderConfig), kafka.NewWriter(infoWriterConfig), kafka.NewWriter(errWriterConfig))
 
 	service.CloseOnSignal(s)
 	waitUntilClosed := s.Start()

--- a/scraper-client/scraper-config.go
+++ b/scraper-client/scraper-config.go
@@ -1,0 +1,21 @@
+package client
+
+import "github.com/codeuniversity/smag-mvp/utils"
+
+type ScraperConfig struct {
+	ElasticAssignmentTimeout int
+	RequestTimeout           int
+	RetryTimeout             int
+	RequestRetryCount        int
+	ElasticIpRetryCount      int
+}
+
+func GetScraperConfig() *ScraperConfig {
+	return &ScraperConfig{
+		ElasticAssignmentTimeout: utils.GetNumberFromEnvWithDefault("ELASTIC_ASSIGNMENT_TIMEOUT", 10000),
+		RequestTimeout:           utils.GetNumberFromEnvWithDefault("REQUEST_TIME", 1000),
+		RetryTimeout:             utils.GetNumberFromEnvWithDefault("RETRY_TIMEOUT", 1000),
+		RequestRetryCount:        utils.GetNumberFromEnvWithDefault("REQUEST_RETRY_COUNT", 3),
+		ElasticIpRetryCount:      utils.GetNumberFromEnvWithDefault("ELASTIC_IP_RETRY_COUNT", 2),
+	}
+}

--- a/scraper-client/scraper-config.go
+++ b/scraper-client/scraper-config.go
@@ -5,7 +5,6 @@ import "github.com/codeuniversity/smag-mvp/utils"
 type ScraperConfig struct {
 	ElasticAssignmentTimeout int
 	RequestTimeout           int
-	RetryTimeout             int
 	RequestRetryCount        int
 	ElasticIpRetryCount      int
 }
@@ -13,8 +12,7 @@ type ScraperConfig struct {
 func GetScraperConfig() *ScraperConfig {
 	return &ScraperConfig{
 		ElasticAssignmentTimeout: utils.GetNumberFromEnvWithDefault("ELASTIC_ASSIGNMENT_TIMEOUT", 10000),
-		RequestTimeout:           utils.GetNumberFromEnvWithDefault("REQUEST_TIME", 1000),
-		RetryTimeout:             utils.GetNumberFromEnvWithDefault("RETRY_TIMEOUT", 1000),
+		RequestTimeout:           utils.GetNumberFromEnvWithDefault("REQUEST_TIMEOUT", 1000),
 		RequestRetryCount:        utils.GetNumberFromEnvWithDefault("REQUEST_RETRY_COUNT", 3),
 		ElasticIpRetryCount:      utils.GetNumberFromEnvWithDefault("ELASTIC_IP_RETRY_COUNT", 2),
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -32,6 +32,17 @@ func GetStringFromEnvWithDefault(enVarName, defaultValue string) string {
 	return envValue
 }
 
+// GetNumberFromEnvWithDefault returns default Value if OS Environment Variable is not set
+func GetNumberFromEnvWithDefault(envVarName string, defaultValue int) int {
+	envValue := os.Getenv(envVarName)
+	number, err := strconv.ParseInt(envValue, 10, 64)
+	if err != nil {
+		return defaultValue
+	}
+
+	return int(number)
+}
+
 //MustGetStringFromEnv panics if OS Environment Variable is not set
 func MustGetStringFromEnv(enVarName string) string {
 	envValue := os.Getenv(enVarName)


### PR DESCRIPTION
# Description

Add new environment variables to the the comments/posts scraper: 
-ElasticIpAssignmentTimeout(if a new elastic ip was assigned to the scraper)
-RequestTimeout
-RequestRetryCount(send request without changing the public ip)  
-ElasticIpRetryCount(if the limit is reached it will execute panic)

Fixes #91 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] is already deployed on our kubernetes cluster

