### PR TITLE
add coalesce to replace NULL values of query response

### DIFF
--- a/api/grpcserver/grpc_server.go
+++ b/api/grpcserver/grpc_server.go
@@ -82,7 +82,11 @@ func (s *GrpcServer) Listen() {
 //GetAllUsersLikeUsername returns a List of users that are like the given username
 func (s *GrpcServer) GetAllUsersLikeUsername(_ context.Context, username *proto.UserNameRequest) (*proto.UserSearchResponse, error) {
 	response := &proto.UserSearchResponse{}
-	rows, err := s.db.Query("SELECT id, user_name, real_name, bio, avatar_url FROM users WHERE LOWER(user_name) LIKE LOWER($1)", fmt.Sprintf("%%%s%%", username.UserName))
+	rows, err := s.db.Query(`SELECT id,  COALESCE(user_name, '') as user_name, 
+										COALESCE(real_name, '') as real_name,
+										COALESCE(bio, '') as bio, 
+										COALESCE(avatar_url, '') as avatar_url 
+										FROM users WHERE LOWER(user_name) LIKE LOWER($1)`, fmt.Sprintf("%%%s%%", username.UserName))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +111,11 @@ func (s *GrpcServer) GetUserWithUsername(_ context.Context, username *proto.User
 	u := &proto.User{}
 	log.Println(username)
 
-	err := s.db.QueryRow("SELECT id, user_name, real_name, bio, avatar_url FROM users WHERE user_name = $1", username.UserName).Scan(&u.Id, &u.UserName, &u.RealName, &u.Bio, &u.AvatarUrl)
+	err := s.db.QueryRow(`SELECT id, COALESCE(user_name, '') as user_name, 
+									COALESCE(real_name, '') as real_name,
+									COALESCE(bio, '') as bio, 
+									COALESCE(avatar_url, '') as avatar_url
+									FROM users WHERE user_name = $1`, username.UserName).Scan(&u.Id, &u.UserName, &u.RealName, &u.Bio, &u.AvatarUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +162,11 @@ func (s *GrpcServer) getRelationsFromUser(query string, userID string, scanFunc 
 func (s *GrpcServer) GetInstaPostsWithUserId(_ context.Context, request *proto.UserIdRequest) (*proto.InstaPostsResponse, error) {
 	res := &proto.InstaPostsResponse{}
 
-	rows, err := s.db.Query("SELECT id, post_id, short_code, caption, internal_picture_url FROM posts WHERE user_id=$1", request.UserId)
+	rows, err := s.db.Query(`SELECT id, COALESCE(post_id, '') as post_id, 
+										COALESCE(short_code, '') as short_code, 
+										COALESCE(caption, '') as caption, 
+										COALESCE(internal_picture_url, '') as internal_picture_url
+										FROM posts WHERE user_id=$1`, request.UserId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Scan cannot handle NULL values in the response. coalesce is added to replace NULL values of the response with a empty string.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Cleanup (changes in structure but not functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

